### PR TITLE
Feature/sharding refactor

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,6 @@
 cleanup_interval: 10s
 heartbeat_interval: 5s
 gossip_peer_count: 2
-v_node_count: 3
-message_timeout: 1s
+v_node_count: 100
+message_timeout: 2s
 replicas: 2
-shards_per_cursor: 16

--- a/config.yml
+++ b/config.yml
@@ -4,5 +4,4 @@ gossip_peer_count: 2
 v_node_count: 3
 message_timeout: 1s
 replicas: 2
-shard_count: 64
 shards_per_cursor: 16

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -47,7 +47,7 @@ type Peer struct {
 // NewClusterManager creates and initializes a new ClusterManager.
 func NewClusterManager(env *environment.Environment, cfg *config.Config) *ClusterManager {
 	cr := registry.NewCommandRegistry()
-	ds := storage.NewDataStore(cfg.Shards, cfg.ShardsPerCursor, cfg.CleanupInterval)
+	ds := storage.NewDataStore(cfg.ShardsPerCursor, cfg.CleanupInterval)
 	peerMap := make(map[string]*Peer)
 	hashRing := hashring.New(cfg.VNodeCount, cfg.Replicas)
 	connPool := pool.NewGrpcConnectionPool(func(address string) (*grpc.ClientConn, error) {

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -222,4 +224,47 @@ func (cm *ClusterManager) GetRandomAlivePeers(num int) []*Peer {
 	}
 
 	return alivePeers[:num]
+}
+
+// parseCursor parses the global cursor string format "node_index.local_cursor".
+func parseCursor(cursorStr string) (nodeIdx, cursor int, err error) {
+	if cursorStr == "" || cursorStr == "0" {
+		return 0, 0, nil
+	}
+
+	parts := strings.SplitN(cursorStr, ".", 2)
+	if len(parts) == 1 {
+		nodeIdx, err = strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid cursor format")
+		}
+		return nodeIdx, 0, nil
+	}
+
+	nodeIdx, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid global cursor format")
+	}
+
+	cursor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid local cursor format")
+	}
+
+	return nodeIdx, cursor, nil
+}
+
+// Finds nodeID responsible for the cursor of the SCAN command
+func (cm *ClusterManager) findCursorNode(key string) ([]string, error) {
+	nodeIdx, _, err := parseCursor(key)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeIDs := cm.HashRing.GetNodes()
+	if nodeIdx >= len(nodeIDs) {
+		return nil, fmt.Errorf("invalid global cursor")
+	}
+
+	return []string{nodeIDs[nodeIdx]}, nil
 }

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -47,7 +47,7 @@ type Peer struct {
 // NewClusterManager creates and initializes a new ClusterManager.
 func NewClusterManager(env *environment.Environment, cfg *config.Config) *ClusterManager {
 	cr := registry.NewCommandRegistry()
-	ds := storage.NewDataStore(cfg.ShardsPerCursor, cfg.CleanupInterval)
+	ds := storage.NewDataStore(cfg.CleanupInterval)
 	peerMap := make(map[string]*Peer)
 	hashRing := hashring.New(cfg.VNodeCount, cfg.Replicas)
 	connPool := pool.NewGrpcConnectionPool(func(address string) (*grpc.ClientConn, error) {

--- a/internal/cluster/rebalance.go
+++ b/internal/cluster/rebalance.go
@@ -163,7 +163,7 @@ func (cm *ClusterManager) Rebalance(oldRing, newRing *hashring.HashRing) {
 	commandsByNode := make(map[string][]*commonpb.CommandRequest)
 	deleteList := make([]string, 0)
 
-	cm.DataStore.Scan(-1, func(key string, store storage.Storable) {
+	cm.DataStore.Scan(-1, 0, func(key string, store storage.Storable) {
 		oldResponsibleNodeIDs := oldRing.Get(key)
 		newResponsibleNodeIDs := newRing.Get(key)
 

--- a/internal/context/config/config.go
+++ b/internal/context/config/config.go
@@ -18,7 +18,6 @@ type Config struct {
 	VNodeCount        int           `yaml:"v_node_count"`
 	MessageTimeout    time.Duration `yaml:"message_timeout"`
 	Replicas          int           `yaml:"replicas"`
-	Shards            int           `yaml:"shard_count"`
 	ShardsPerCursor   int           `yaml:"shards_per_cursor"`
 }
 
@@ -30,7 +29,6 @@ func Default() *Config {
 		VNodeCount:        3,
 		MessageTimeout:    1 * time.Second,
 		Replicas:          2,
-		Shards:            512,
 		ShardsPerCursor:   128,
 	}
 }

--- a/internal/context/config/config.go
+++ b/internal/context/config/config.go
@@ -18,7 +18,6 @@ type Config struct {
 	VNodeCount        int           `yaml:"v_node_count"`
 	MessageTimeout    time.Duration `yaml:"message_timeout"`
 	Replicas          int           `yaml:"replicas"`
-	ShardsPerCursor   int           `yaml:"shards_per_cursor"`
 }
 
 func Default() *Config {
@@ -26,10 +25,9 @@ func Default() *Config {
 		CleanupInterval:   10 * time.Second,
 		HeartbeatInterval: 5 * time.Second,
 		GossipPeerCount:   2,
-		VNodeCount:        3,
+		VNodeCount:        100,
 		MessageTimeout:    1 * time.Second,
 		Replicas:          2,
-		ShardsPerCursor:   128,
 	}
 }
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -127,10 +127,10 @@ func (ds *DataStore) Del(key string) {
 }
 
 // Scan iterates over all keys in a specific cursor range and calls the callback.
-func (ds *DataStore) Scan(cursor int, callback func(key string, val Storable)) {
+func (ds *DataStore) Scan(cursor, count int, callback func(key string, val Storable)) {
 	now := time.Now().Unix()
-	start := 0
-	end := int(ds.ShardsCount)
+	start := cursor
+	end := cursor + count
 
 	if cursor == -1 {
 		start = 0

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -37,19 +37,17 @@ type shard struct {
 
 // DataStore is the unified, thread-safe, sharded key-value store.
 type DataStore struct {
-	shards          []*shard
-	janitor         *janitor
-	ShardsCount     uint64
-	ShardsPerCursor int
+	shards      []*shard
+	janitor     *janitor
+	ShardsCount uint64
 }
 
 // NewDataStore creates a new DataStore with a background cleanup goroutine.
-func NewDataStore(shardsPerCursor int, cleanupInterval time.Duration) *DataStore {
+func NewDataStore(cleanupInterval time.Duration) *DataStore {
 	shardsCount := getShardCount()
 	ds := &DataStore{
-		shards:          make([]*shard, shardsCount),
-		ShardsCount:     uint64(shardsCount),
-		ShardsPerCursor: shardsPerCursor,
+		shards:      make([]*shard, shardsCount),
+		ShardsCount: uint64(shardsCount),
 	}
 
 	for i := range shardsCount {
@@ -131,8 +129,8 @@ func (ds *DataStore) Del(key string) {
 // Scan iterates over all keys in a specific cursor range and calls the callback.
 func (ds *DataStore) Scan(cursor int, callback func(key string, val Storable)) {
 	now := time.Now().Unix()
-	start := cursor * ds.ShardsPerCursor
-	end := start + ds.ShardsPerCursor
+	start := 0
+	end := int(ds.ShardsCount)
 
 	if cursor == -1 {
 		start = 0

--- a/proto/commonpb/common_helpers.go
+++ b/proto/commonpb/common_helpers.go
@@ -38,10 +38,11 @@ func NewMap(m map[string]*Value) *Value {
 	}
 }
 
-func NewCursor(cursor uint64, data *Value) *Value {
+func NewCursor(cursor uint64, count int, data *Value) *Value {
 	payload := make(map[string]*Value, 2)
 	payload["cursor"] = NewInt(int64(cursor))
 	payload["data"] = data
+	payload["count"] = NewInt(int64(count))
 	return NewMap(payload)
 }
 

--- a/proto/commonpb/common_helpers.go
+++ b/proto/commonpb/common_helpers.go
@@ -38,11 +38,11 @@ func NewMap(m map[string]*Value) *Value {
 	}
 }
 
-func NewCursor(cursor uint64, count int, data *Value) *Value {
+func NewCursor(cursor string, count int, data *Value) *Value {
 	payload := make(map[string]*Value, 2)
-	payload["cursor"] = NewInt(int64(cursor))
-	payload["data"] = data
+	payload["cursor"] = NewString(cursor)
 	payload["count"] = NewInt(int64(count))
+	payload["data"] = data
 	return NewMap(payload)
 }
 


### PR DESCRIPTION
Removed `shard_count` and `shards_per_cursor` variables from config.yml.
Shard number dynamically set to number of cpus * factor of 4 rounded to next power of two (to allow bitwise operation for getShard instead of module operation).
Updated HashRing hashing algo for faster one, and Get/GetNodes methods logic.
Increased `v_node_count` and `message_timeout` defaults.
Refactor scan to take cursor in pattern 0.0 (nodeIdx.shardNumber) and takes a optional count arg (number of shards to scan, defaults to 4).
